### PR TITLE
AMS-3326 Multiple fixes for scripting issues

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
     <parent>
         <groupId>com.polopoly</groupId>
         <artifactId>public</artifactId>
-        <version>10.18.3</version>
+        <version>10.20.0</version>
         <relativePath />
     </parent>
 
@@ -66,7 +66,7 @@
     <properties>
         <maven.compiler.source>8</maven.compiler.source>
         <maven.compiler.target>8</maven.compiler.target>
-        <polopoly.version>10.18.3-fp2</polopoly.version>
+        <polopoly.version>10.20.0</polopoly.version>
         <desk.version>2.14.0-SNAPSHOT</desk.version>
     </properties>
 

--- a/src/main/java/com/atex/onecms/scripting/LifecycleScriptingEngine.java
+++ b/src/main/java/com/atex/onecms/scripting/LifecycleScriptingEngine.java
@@ -66,7 +66,7 @@ public final class LifecycleScriptingEngine {
         contentManager = cm;
         scriptCache = CacheBuilder.newBuilder()
                                 .maximumSize(1000)
-                                .expireAfterAccess(5, TimeUnit.SECONDS)
+                                .expireAfterWrite(20, TimeUnit.SECONDS)
                                 .build(new CacheLoader<String, CompilableScript>() {
                                     @Override
                                     @ParametersAreNonnullByDefault
@@ -76,7 +76,7 @@ public final class LifecycleScriptingEngine {
                                             ContentResult<LifecycleScript> result = cm.get(versionId,
                                                     LifecycleScript.class,
                                                     Subject.NOBODY_CALLER);
-                                            if (result.getStatus().equals(Status.OK)) {
+                                            if (result != null && Status.OK.equals(result.getStatus())) {
                                                 return new CompilableScript(result.getContent().getContentData());
                                             }
                                         }

--- a/src/main/java/com/atex/onecms/scripting/workflow/PartitionUtils.java
+++ b/src/main/java/com/atex/onecms/scripting/workflow/PartitionUtils.java
@@ -1,0 +1,51 @@
+package com.atex.onecms.scripting.workflow;
+
+import com.atex.onecms.content.ContentWrite;
+import com.atex.onecms.content.ContentWriteBuilder;
+import com.atex.onecms.content.metadata.MetadataInfo;
+import com.polopoly.metadata.Dimension;
+import com.polopoly.metadata.Entity;
+import com.polopoly.metadata.Metadata;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public final class PartitionUtils {
+
+    private static final String PARTITION_DIMENSION_ID = "dimension.partition";
+
+    private PartitionUtils() { }
+
+    public static <T> ContentWrite<T> changePartition(final ContentWrite<T> cw, final String partitionId) {
+        ContentWriteBuilder<T> cwb = new ContentWriteBuilder<>();
+        cwb.origin(cw.getId());
+        cwb.type(cw.getContentDataType());
+        cwb.aspects(cw.getAspects());
+        cwb.mainAspectData(cw.getContentData());
+
+        MetadataInfo metadataInfo = cw.getAspect(MetadataInfo.ASPECT_NAME, MetadataInfo.class);
+        if (metadataInfo != null) {
+            //clear out partition dimension
+            Metadata metadata = metadataInfo.getMetadata();
+            if (metadata != null) {
+                List<Dimension> dimensions = new ArrayList();
+                for (Dimension dimension : metadata.getDimensions()) {
+                    if (!dimension.getId().equals(PARTITION_DIMENSION_ID)) {
+                        dimensions.add(dimension);
+                    }
+                }
+                Dimension paramDimension = createDimensionWithEntity(PARTITION_DIMENSION_ID, partitionId);
+                dimensions.add(paramDimension);
+                metadata.setDimensions(dimensions);
+            }
+
+            cwb.aspect(MetadataInfo.ASPECT_NAME, metadataInfo);
+        }
+
+        return cwb.buildUpdate();
+    }
+
+    private static Dimension createDimensionWithEntity(final String dimension, final String entity) {
+        return new Dimension(dimension, dimension, false, new Entity(entity, entity));
+    }
+}

--- a/src/main/resources/com/atex/onecms/scripting/script-util.js
+++ b/src/main/resources/com/atex/onecms/scripting/script-util.js
@@ -20,7 +20,11 @@ function resolve(externalId) {
  * @param {String} partitionName The name of the partition to set.
  */
 function setPartition(content, partitionName) {
-    var PartitionUtils = Java.type('com.atex.workflow.PartitionUtils');
+    var PartitionUtils = Java.type('com.atex.onecms.scripting.workflow.PartitionUtils');
+
+    if (content instanceof Java.type('com.atex.onecms.scripting.api.BaseJSObject')) {
+        content = content.getContentWrite();
+    }
     PartitionUtils.changePartition(content, partitionName);
 }
 
@@ -36,6 +40,9 @@ function setWFStatus(content, statusId) {
     if (statusBean === null) {
         throw new Error('No status with the ID "' + statusId + '"');
     }
+    if (content instanceof Java.type('com.atex.onecms.scripting.api.BaseJSObject')) {
+        content = content.getContentWrite();
+    }
     var contentStatusBean = content.getAspect(Java.type('com.atex.onecms.app.dam.workflow.WFContentStatusAspectBean').ASPECT_NAME);
     contentStatusBean.setStatus(statusBean);
 }
@@ -48,6 +55,9 @@ function setWFStatus(content, statusId) {
 function setWebStatus(content, statusId) {
     var WebStatusUtils = Java.type('com.atex.workflow.WebStatusUtils');
     var wsUtils = new WebStatusUtils(contentManager);
+    if (content instanceof Java.type('com.atex.onecms.scripting.api.BaseJSObject')) {
+        content = content.getContentWrite();
+    }
     wsUtils.setWebStatus(content, statusId);
 }
 /**


### PR DESCRIPTION
- Add PartitionUtils.java for use with script-util.js.
- Update script caching strategy to use expireAfterWrite.
- Update script-util.js to determine between ContentWrite and ContentFacade when necessary.
- Add tests for script util functions and script cache updates.
- Update polopoly version to 10.20.0.